### PR TITLE
Fix: Handling Jump Synchronization Exception

### DIFF
--- a/ClockMate/Assets/Scripts/Player/CharacterBase.cs
+++ b/ClockMate/Assets/Scripts/Player/CharacterBase.cs
@@ -101,10 +101,13 @@ public abstract class CharacterBase : MonoBehaviourPun
         _rb.velocity = new Vector3(_rb.velocity.x, 0f, _rb.velocity.z); // 점프 전 y 속도(추락 속도) 제거
         _rb.AddForce(Vector3.up * jumpPower, ForceMode.Impulse); // 점프 힘 적용
         JumpCount++;
-        
+
         // 다른 클라이언트에게 동기화
-        _photonView.RPC(nameof(RPC_SyncJump), RpcTarget.Others, transform.position, jumpPower);
-        
+        if (NetworkManager.Instance != null && NetworkManager.Instance.IsInRoomAndReady() && photonView.IsMine)
+        {
+            _photonView.RPC(nameof(RPC_SyncJump), RpcTarget.Others, transform.position, jumpPower);
+        }
+
         _photonTransformView.enabled = true;
     }
 


### PR DESCRIPTION
- 점프 동기화 예외 처리

- 네트워크에 접속해있지 않거나 방에 들어와 있지 않을 때에도 점프 RPC를 호출하여 발생하는 문제 해결 완료

@konguksu
> 실제 게임 실행 시 타이틀부터 시작하면 NetworkManager.Instance가 null인 경우는 발생하지 않으나, 테스트 진행 시에는 없는 경우도 있으므로 NetworkManager.Instance != null 추가함. 상황에 따라 유동적으로 추가/제외 가능