### PR TITLE
fix: interaction detection to ignore height

### DIFF
--- a/ClockMate/Assets/02.Scripts/Player/InteractionDetector.cs
+++ b/ClockMate/Assets/02.Scripts/Player/InteractionDetector.cs
@@ -82,13 +82,21 @@ public class InteractionDetector : MonoBehaviour
             IInteractable interactable = pair.Value;
             
             if (targetObj == null) continue;
-            
+
             // 거리 조건
-            float distance = Vector3.Distance(targetObj.transform.position, _character.transform.position);
+            Vector3 charPos = _character.transform.position;
+            Vector3 targetObjPos = targetObj.transform.position;
+
+            charPos.y = 0;
+            targetObjPos.y = 0;
+
+            float distance = Vector3.Distance(charPos, targetObjPos);
             if (distance > interactDistance) continue;
 
             // 시야각 조건
-            Vector3 direction = targetObj.transform.position - _character.transform.position;
+            Vector3 direction = (targetObjPos - charPos).normalized;
+            Vector3 forward = _character.transform.forward;
+            forward.y = 0;
             float angle = Vector3.Angle(_character.transform.forward, direction);
             if (angle > interactAngle) continue;
 


### PR DESCRIPTION
- InteractionDetector.cs에서 상호작용 가능한 오브젝트와 플레이어와의 거리, 시야각을 각자의 position을 기준으로 계산하고 있어, 높이가 높은 오브젝트는 가까이 가도 멀리 있는 것으로 인식하여 UI가 정상적으로 띄워지지 않는 문제 해결 완료
- 트리거에 들어온 오브젝트들과의 거리만 계산하는 것이기 때문에 x, z 값만 고려하도록 수정