### PR TITLE
fix: resolve destroy clock hand bug

### DIFF
--- a/ClockMate/Assets/01.Scenes/ClockTower.unity
+++ b/ClockMate/Assets/01.Scenes/ClockTower.unity
@@ -456,7 +456,7 @@ MonoBehaviour:
   minBattleFieldXZ: {x: -5, y: -5}
   maxBattleFieldXZ: {x: 5, y: 5}
   pendulumPool: {fileID: 512342076}
-  clockhandPool: {fileID: 0}
+  clockhandPool: {fileID: 627350063}
   recoverySlider: {fileID: 522222844}
   round: 1
 --- !u!4 &204318377
@@ -1040,7 +1040,7 @@ GameObject:
   - component: {fileID: 627350064}
   - component: {fileID: 627350063}
   m_Layer: 0
-  m_Name: FallingNeedlePool
+  m_Name: ClockHandPool
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/ClockMate/Assets/02.Scripts/ClockTower/BattleManager.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/BattleManager.cs
@@ -69,8 +69,8 @@ public class BattleManager : MonoBehaviourPunCallbacks
         };
 
         // StageLifeManager ÆÄ±«
-        if (StageLifeManager.Instance != null)
-            Destroy(StageLifeManager.Instance);
+        //if (StageLifeManager.Instance != null)
+        //    Destroy(StageLifeManager.Instance);
 
         screenEffectController = FindObjectOfType<ScreenEffectController>();
     }

--- a/ClockMate/Assets/02.Scripts/ClockTower/PlayerAttack/ClockHandController.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/PlayerAttack/ClockHandController.cs
@@ -1,0 +1,104 @@
+using Photon.Pun;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem.XR;
+
+public class ClockHandController : MonoBehaviourPun
+{
+    private Rigidbody _rb;
+    private IAClockHand iAClockHand;
+
+    private const float ControllerOffset = 1.2f;
+
+    private void Awake()
+    {
+        _rb = GetComponentInChildren<Rigidbody>();
+        _rb.isKinematic = true;
+
+        iAClockHand = GetComponentInChildren<IAClockHand>();
+    }
+
+    [PunRPC]
+    public void RPC_Rotate(float rotationAmount)
+    {
+        transform.root.Rotate(0f, rotationAmount, 0f);
+    }
+
+    [PunRPC]
+    public void RPC_DetachController(int controllerViewID)
+    {
+        PhotonView controllerView = PhotonView.Find(controllerViewID);
+        if (controllerView == null) return;
+
+        Collider[] handColliders = GetComponentsInChildren<Collider>();
+        Collider[] controllerColliders = controllerView.GetComponents<Collider>();
+
+        foreach (var controllerCol in controllerColliders)
+        {
+            foreach (var handCol in handColliders)
+            {
+                Physics.IgnoreCollision(controllerCol, handCol, false);
+            }
+        }
+
+        foreach (var handCol in handColliders)
+        {
+            handCol.enabled = true;
+        }
+
+        controllerView.GetComponent<Rigidbody>().isKinematic = false;
+        _rb.isKinematic = true;
+
+        controllerView.transform.SetParent(null);
+        controllerView.GetComponent<PhotonTransformView>().enabled = true;
+    }
+
+    [PunRPC]
+    public void RPC_AttachController(int controllerViewID)
+    {
+        PhotonView controllerView = PhotonView.Find(controllerViewID);
+        if (controllerView == null) return;
+
+        Collider[] handColliders = GetComponentsInChildren<Collider>();
+        Collider[] controllerColliders = controllerView.GetComponents<Collider>();
+
+        foreach (var controllerCol in controllerColliders)
+        {
+            foreach (var handCol in handColliders)
+            {
+                // 시계 바늘과 플레이어의 충돌 무시
+                Physics.IgnoreCollision(controllerCol, handCol, true);
+            }
+        }
+
+        foreach (var handCol in handColliders)
+        {
+            handCol.enabled = false;
+        }
+
+        controllerView.GetComponent<Rigidbody>().isKinematic = true;
+
+        PhotonTransformView photonTransformView = controllerView.GetComponent<PhotonTransformView>();
+        photonTransformView.enabled = false;
+
+        _rb.isKinematic = false;
+
+        controllerView.transform.SetParent(iAClockHand.meshRenderer.transform);
+
+        float originControllerY = controllerView.transform.position.y;
+        Vector3 right = transform.right;
+        right.y = 0f;
+        right.Normalize();
+
+        Vector3 toPlayer = controllerView.transform.position - iAClockHand.meshRenderer.transform.position;
+        float side = Vector3.Dot(toPlayer, right);
+        Vector3 attachDir = side >= 0 ? right : -right;
+
+        Vector3 targetPos = iAClockHand.transform.position + attachDir * ControllerOffset;
+        targetPos.y = originControllerY;
+
+        controllerView.transform.position = targetPos;
+        controllerView.transform.rotation = Quaternion.LookRotation(-attachDir);
+    }
+}

--- a/ClockMate/Assets/02.Scripts/ClockTower/PlayerAttack/ClockHandController.cs.meta
+++ b/ClockMate/Assets/02.Scripts/ClockTower/PlayerAttack/ClockHandController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b7ba555bff2d3841b125ba1b1667578
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ClockMate/Assets/02.Scripts/ClockTower/PlayerAttack/ClockHandRecovery.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/PlayerAttack/ClockHandRecovery.cs
@@ -207,15 +207,6 @@ public class ClockHandRecovery : AttackPattern
 
     public override void CancelAttack() { }
 
-    void ClearRecovery()
-    {
-        PhotonNetwork.Destroy(hourClockHand);
-        PhotonNetwork.Destroy(minuteClockHand);
-
-        hourClockHandUI.GetComponent<Image>().enabled = false;
-        minuteClockHandUI.GetComponent<Image>().enabled = false;
-    }
-
     [PunRPC]
     void RPC_DetachAllPlayers()
     {
@@ -226,13 +217,27 @@ public class ClockHandRecovery : AttackPattern
         minute?.ExitControl();
     }
 
+    [PunRPC]
+    private void RPC_DisableUI()
+    {
+        hourClockHandUI.GetComponent<Image>().enabled = false;
+        minuteClockHandUI.GetComponent<Image>().enabled = false;
+    }
+
     void EndRecovery(bool isSuccess)
     {
-        if (!PhotonNetwork.IsMasterClient) return;
-        
         photonView.RPC(nameof(RPC_DetachAllPlayers), RpcTarget.All);
-        ClearRecovery();
-        BattleManager.Instance.photonView.RPC("ReportAttackResult", RpcTarget.All, isSuccess);
 
+        photonView.RPC(nameof(RPC_DisableUI), RpcTarget.All);
+
+        if (hourClockHand != null)
+            PhotonNetwork.Destroy(hourClockHand);
+        if (minuteClockHand != null)
+            PhotonNetwork.Destroy(minuteClockHand);
+
+        hourClockHand = null;
+        minuteClockHand = null;
+
+        BattleManager.Instance.photonView.RPC("ReportAttackResult", RpcTarget.All, isSuccess);
     }
 }

--- a/ClockMate/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/ClockMate/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -114,6 +114,7 @@ MonoBehaviour:
   - RPC_EnableTimeLimit
   - ClearRecovery
   - RPC_ClearRecovery
+  - RPC_DisableUI
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/ClockMate/Assets/Resources/Prefabs/RecoveryHourClockHand.prefab
+++ b/ClockMate/Assets/Resources/Prefabs/RecoveryHourClockHand.prefab
@@ -11,9 +11,8 @@ GameObject:
   - component: {fileID: 1419449293861180711}
   - component: {fileID: 6754520202128000649}
   - component: {fileID: 4075927613350354889}
-  - component: {fileID: 4899970666681466690}
   - component: {fileID: 4204097770649566463}
-  - component: {fileID: 5966025449389933465}
+  - component: {fileID: 1187330577080578754}
   m_Layer: 0
   m_Name: Hinge
   m_TagString: Untagged
@@ -102,20 +101,6 @@ HingeJoint:
   m_EnablePreprocessing: 1
   m_MassScale: 1
   m_ConnectedMassScale: 1
---- !u!114 &4899970666681466690
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2934540344760838738}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19c9e4dfb6a48324390f675b94fe4d98, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ControllerName: 0
-  meshRenderer: {fileID: 4205925411451221047}
 --- !u!65 &4204097770649566463
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -137,7 +122,7 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 7.5}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &5966025449389933465
+--- !u!114 &1187330577080578754
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -146,19 +131,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 2934540344760838738}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Script: {fileID: 11500000, guid: 19c9e4dfb6a48324390f675b94fe4d98, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ObservedComponentsFoldoutOpen: 1
-  Group: 0
-  prefixField: -1
-  Synchronization: 0
-  OwnershipTransfer: 0
-  observableSearch: 2
-  ObservedComponents: []
-  sceneViewId: 0
-  InstantiationId: 0
-  isRuntimeInstantiated: 0
+  ControllerName: 0
+  meshRenderer: {fileID: 4205925411451221047}
 --- !u!1 &7187283922675596617
 GameObject:
   m_ObjectHideFlags: 0
@@ -168,6 +145,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8566395899150888786}
+  - component: {fileID: 8704708449161550208}
+  - component: {fileID: 5878849527764007596}
   m_Layer: 0
   m_Name: RecoveryHourClockHand
   m_TagString: Untagged
@@ -192,6 +171,40 @@ Transform:
   - {fileID: 1276970779856286543}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8704708449161550208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7187283922675596617}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
+--- !u!114 &5878849527764007596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7187283922675596617}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b7ba555bff2d3841b125ba1b1667578, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1599357679298303140
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ClockMate/Assets/Resources/Prefabs/RecoveryMinuteClockHand.prefab
+++ b/ClockMate/Assets/Resources/Prefabs/RecoveryMinuteClockHand.prefab
@@ -9,6 +9,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8840461621351823630}
+  - component: {fileID: 6489966744402111685}
+  - component: {fileID: 1310327958638984975}
   m_Layer: 0
   m_Name: RecoveryMinuteClockHand
   m_TagString: Untagged
@@ -33,6 +35,40 @@ Transform:
   - {fileID: 3198095524407286704}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6489966744402111685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3190810293514739049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
+--- !u!114 &1310327958638984975
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3190810293514739049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b7ba555bff2d3841b125ba1b1667578, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8506099953192983385
 GameObject:
   m_ObjectHideFlags: 0
@@ -44,9 +80,8 @@ GameObject:
   - component: {fileID: 4978225814192937795}
   - component: {fileID: 4134481225524082338}
   - component: {fileID: 2139486525152085790}
-  - component: {fileID: 779748719130194980}
   - component: {fileID: 3335698434488601612}
-  - component: {fileID: 8665135839303112550}
+  - component: {fileID: 5066403029328286616}
   m_Layer: 0
   m_Name: Hinge
   m_TagString: Untagged
@@ -108,7 +143,7 @@ HingeJoint:
   m_Anchor: {x: 0, y: 0, z: 0}
   m_Axis: {x: 0, y: 1, z: 0}
   m_AutoConfigureConnectedAnchor: 1
-  m_ConnectedAnchor: {x: 4.11, y: 0, z: 4.5}
+  m_ConnectedAnchor: {x: 4.11, y: 1, z: 2}
   serializedVersion: 2
   m_UseSpring: 0
   m_Spring:
@@ -135,20 +170,6 @@ HingeJoint:
   m_EnablePreprocessing: 1
   m_MassScale: 1
   m_ConnectedMassScale: 1
---- !u!114 &779748719130194980
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8506099953192983385}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19c9e4dfb6a48324390f675b94fe4d98, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ControllerName: 1
-  meshRenderer: {fileID: 4764043993684796243}
 --- !u!65 &3335698434488601612
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -170,7 +191,7 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 9}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &8665135839303112550
+--- !u!114 &5066403029328286616
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -179,19 +200,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 8506099953192983385}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Script: {fileID: 11500000, guid: 19c9e4dfb6a48324390f675b94fe4d98, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ObservedComponentsFoldoutOpen: 1
-  Group: 0
-  prefixField: -1
-  Synchronization: 0
-  OwnershipTransfer: 0
-  observableSearch: 2
-  ObservedComponents: []
-  sceneViewId: 0
-  InstantiationId: 0
-  isRuntimeInstantiated: 0
+  ControllerName: 1
+  meshRenderer: {fileID: 4764043993684796243}
 --- !u!1001 &3164715050035149915
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
- 시계 바늘 복구 공격 후 비마스터에서 시계 바늘 오브젝트가 사라지지 않는 문제 해결 완료
- 포톤 뷰가 최상단 부모가 아닌 자식에 있어 발생한 문제로, 포톤 뷰를 최상단 부모로 옮겼다. 한 오브젝트에 포톤 뷰가 두 개 이상 있으면 추후 꼬일 수 있으므로, IAClockHand 스크립트가 붙어있는 자식 오브젝트에는 포톤 뷰를 제거하였다. 이로 인해 IAClockHand에서 정상적으로 RPC 함수를 사용할 수 없으므로, IInteractable 재정의 함수는 놔두고 RPC 함수를 다른 스크립트로 옮겨 최상단 오브젝트에 넣어주었다.