### PR TITLE
feat: prevent photon ID appearing in PhotonServerSettings after running editor

### DIFF
--- a/ClockMate/Assets/02.Scripts/Game/VoiceManager.cs
+++ b/ClockMate/Assets/02.Scripts/Game/VoiceManager.cs
@@ -1,4 +1,5 @@
 using Photon.Pun;
+using Photon.Realtime;
 using Photon.Voice;
 using Photon.Voice.PUN;
 using Photon.Voice.Unity;
@@ -26,11 +27,26 @@ public class VoiceManager : MonoBehaviour
         if (voiceClient == null)
         {
             voiceClient = GetComponent<PunVoiceClient>();
+            GetComponent<VoiceFollowClient>().enabled = false;
+
+
         }
         if (recorder == null)
         {
             recorder = GetComponent<Recorder>();
             SetMicActive(false);
+        }
+    }
+
+    public void ConnectVoice(AppSettings appSettings)
+    {
+        if(voiceClient != null)
+        {
+            voiceClient.ConnectUsingSettings(appSettings);
+        }
+        else
+        {
+            Debug.LogError("PunVoiceClient가 존재하지 않거나 이미 연결되어 있어 Voice 연결을 시작할 수 없습니다.");
         }
     }
 

--- a/ClockMate/Assets/02.Scripts/UI/PuzzleHUD.cs
+++ b/ClockMate/Assets/02.Scripts/UI/PuzzleHUD.cs
@@ -34,7 +34,7 @@ public class PuzzleHUD : UIBase
             _remotePhotonVoiceView = GameObject.FindWithTag(remotePlayerName)?.GetComponent<PhotonVoiceView>();
         }
 
-        Sprite characterSprite = Resources.Load<Sprite>("UI/Sprites/Character" + remotePlayerName + "Icon");
+        Sprite characterSprite = Resources.Load<Sprite>("UI/Sprites/Character/" + remotePlayerName + "Icon");
         if (characterSprite == null)
         {
             Debug.LogWarning($"Sprite for {remotePlayerName} not found in Resources.");

--- a/ClockMate/Assets/02.Scripts/Util/EnvLoader.cs
+++ b/ClockMate/Assets/02.Scripts/Util/EnvLoader.cs
@@ -15,7 +15,7 @@ public static class EnvLoader
 
         if (!File.Exists(envPath))
         {
-            Debug.LogWarning("'.env' 파일이 존재하지 않습니다. App ID가 로드되지 않습니다.");
+            Debug.LogWarning("'.env' 파일이 존재하지 않습니다. 환경 변수가 로드되지 않습니다.");
             return;
         }
 

--- a/ClockMate/Assets/05.Prefabs/Common/VoiceManager.prefab
+++ b/ClockMate/Assets/05.Prefabs/Common/VoiceManager.prefab
@@ -62,7 +62,7 @@ MonoBehaviour:
     AppIdVoice: 
     AppVersion: 
     UseNameServer: 1
-    FixedRegion: 
+    FixedRegion: kr
     Server: 
     Port: 0
     ProxyServer: 
@@ -72,8 +72,8 @@ MonoBehaviour:
     EnableLobbyStatistics: 0
     NetworkLogging: 1
   ShowSettings: 1
-  AutoConnectAndJoin: 1
-  usePunAppSettings: 1
+  AutoConnectAndJoin: 0
+  usePunAppSettings: 0
   usePunAuthValues: 1
 --- !u!114 &4623098362447979165
 MonoBehaviour:

--- a/ClockMate/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/ClockMate/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -13,10 +13,10 @@ MonoBehaviour:
   m_Name: PhotonServerSettings
   m_EditorClassIdentifier: 
   AppSettings:
-    AppIdRealtime: [REMOVED]
+    AppIdRealtime: 
     AppIdFusion: 
     AppIdChat: 
-    AppIdVoice: [REMOVED]
+    AppIdVoice: 
     AppVersion: 
     UseNameServer: 1
     FixedRegion: kr


### PR DESCRIPTION
- 에디터 실행 후 PhotonServerSettings에 포톤 아이디가 뜨는 문제 예방
- 테스트 서버에 새로운 포톤 연결 법 적용
- 아워가 동기화 안 되는 문제 해결 필요