### PR TITLE
feat: synchronize player dead and revive effect

### DIFF
--- a/ClockMate/Assets/02.Scripts/ClockTower/Life/BattleLifeManager.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/Life/BattleLifeManager.cs
@@ -51,7 +51,7 @@ public class BattleLifeManager : MonoBehaviourPun
         Vector3 revivePos = strategy.GetRevivePosition();
         character.transform.position = revivePos;
 
-        character.ChangeState<IdleState>(); // TODO 정상적으로 동기화 되는지 확인할 것!
+        character.ChangeState<IdleState>();
         deadPlayers.Remove(character.GetComponent<PhotonView>().ViewID);
     }
 

--- a/ClockMate/Assets/02.Scripts/Network/RPCManager.cs
+++ b/ClockMate/Assets/02.Scripts/Network/RPCManager.cs
@@ -213,4 +213,14 @@ public class RPCManager : MonoBehaviourPunCallbacks
 
         StageLifeManager.Instance.TryRevive();
     }
+
+    [PunRPC]
+    public void RPC_SetObjectActive(int viewID, bool active)
+    {
+        PhotonView targetView = PhotonView.Find(viewID);
+        if(targetView != null)
+        {
+            targetView.gameObject.SetActive(active);
+        }
+    }
 }

--- a/ClockMate/Assets/02.Scripts/Player/CharacterBase.cs
+++ b/ClockMate/Assets/02.Scripts/Player/CharacterBase.cs
@@ -267,6 +267,12 @@ public abstract class CharacterBase : MonoBehaviourPun
         _curReviveCoroutine = StartCoroutine(HandleReviveEffect());
     }
 
+    [PunRPC]
+    public void RPC_PlayReviveEffect()
+    {
+        PlayReviveEffect();
+    }
+
     /// <summary>
     /// 이펙트 재생 및 종료 처리
     /// </summary>

--- a/ClockMate/Assets/02.Scripts/Player/States/DeadState.cs
+++ b/ClockMate/Assets/02.Scripts/Player/States/DeadState.cs
@@ -17,7 +17,7 @@ public class DeadState : IState
 
     public void Enter()
     {
-        _character.gameObject.SetActive(false);
+        RPCManager.Instance.photonView.RPC("RPC_SetObjectActive", Photon.Pun.RpcTarget.All, _character.photonView.ViewID, false);
 
         if (SceneManager.GetActiveScene().name == "ClockTower")
         {
@@ -48,7 +48,7 @@ public class DeadState : IState
 
     public void Exit()
     {
-        _character.gameObject.SetActive(true);
-        _character.PlayReviveEffect();
+        RPCManager.Instance.photonView.RPC("RPC_SetObjectActive", Photon.Pun.RpcTarget.All, _character.photonView.ViewID, true);
+        _character.photonView.RPC("RPC_PlayReviveEffect", Photon.Pun.RpcTarget.All);
     }
 }

--- a/ClockMate/Assets/05.Prefabs/ClockTower/BattleManager.prefab
+++ b/ClockMate/Assets/05.Prefabs/ClockTower/BattleManager.prefab
@@ -56,9 +56,8 @@ MonoBehaviour:
   - {fileID: 4467992356540520643, guid: f6ff2eeb3a426e74cb459625384b9df1, type: 3}
   pendulumPool: {fileID: 0}
   clockhandPool: {fileID: 0}
-  bossAttackFloor: {fileID: 0}
+  clockFace: {fileID: 0}
   recoverySlider: {fileID: 0}
-  round: 1
   battleFieldRadius: 5
 --- !u!114 &7793861500124977112
 MonoBehaviour:

--- a/ClockMate/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/ClockMate/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -140,6 +140,8 @@ MonoBehaviour:
   - BossToPlayerTransition
   - HandleFailure
   - HandleSuccess
+  - RPC_PlayReviveEffect
+  - RPC_SetObjectActive
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1


### PR DESCRIPTION
- RPCManager에 오브젝트 활성화 설정 함수 추가
- 플레이어 죽음 시 활성화/비활성화 상태 동기화
- 부활 이펙트 동기화