### PR TITLE
fix: battle physics bug

### DIFF
--- a/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/FallingClockHand.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/FallingClockHand.cs
@@ -24,6 +24,9 @@ public class FallingClockHand : MonoBehaviourPun
 
     private void OnEnable()
     {
+        _killTrigger.enabled = true;
+        _solidCollider.enabled = false;
+
         _rb.isKinematic = false;
         _rb.velocity = Vector3.zero;
         _rb.angularVelocity = Vector3.zero;

--- a/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/FallingClockHand.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/FallingClockHand.cs
@@ -75,10 +75,9 @@ public class FallingClockHand : MonoBehaviourPun
             StartCoroutine(ReturnAfterDelay());
         }
 
-        if (collision.collider.IsPlayerCollider())
+        CharacterBase character = collision.collider.GetComponentInParent<CharacterBase>();
+        if (character != null)
         {
-            // 플레이어 사망 처리
-            CharacterBase character = collision.collider.GetComponentInParent<CharacterBase>();
             BattleLifeManager.Instance.RecordHitPosition(character, character.transform.position);
             character.ChangeState<DeadState>(Define.Battle.DeathType.Collision);
         }

--- a/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/FallingClockHand.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/FallingClockHand.cs
@@ -83,9 +83,10 @@ public class FallingClockHand : MonoBehaviourPun
         else
         {
             CharacterBase character = other.GetComponentInParent<CharacterBase>();
-
             // 상호작용 트리거로 죽지 않도록 플레이어 태그도 검사
-            if (other.IsPlayerCollider() && character != null && _killTrigger.enabled)
+            bool canDie = other.IsPlayerCollider() && character != null && _killTrigger.enabled && character.photonView.IsMine;
+
+            if (canDie)
             {
                 BattleLifeManager.Instance.RecordHitPosition(character, character.transform.position);
                 character.ChangeState<DeadState>(Define.Battle.DeathType.Collision);

--- a/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/FallingClockHand.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/FallingClockHand.cs
@@ -6,7 +6,9 @@ using UnityEngine;
 
 public class FallingClockHand : MonoBehaviourPun
 {
-    private Rigidbody rb;
+    private Rigidbody _rb;
+    [SerializeField] private Collider _killTrigger;   // 플레이어 죽이는 전용 트리거
+    [SerializeField] private Collider _solidCollider; // 물리 충돌용 트리거
 
     private const float fallForce = 700f;
     private const float lifeTime = 3f;
@@ -17,14 +19,14 @@ public class FallingClockHand : MonoBehaviourPun
 
     private void Awake()
     {
-        rb = GetComponent<Rigidbody>();
+        _rb = GetComponent<Rigidbody>();
     }
 
     private void OnEnable()
     {
-        rb.isKinematic = false;
-        rb.velocity = Vector3.zero;
-        rb.angularVelocity = Vector3.zero;
+        _rb.isKinematic = false;
+        _rb.velocity = Vector3.zero;
+        _rb.angularVelocity = Vector3.zero;
 
         if (PhotonNetwork.IsMasterClient)
             photonView.RPC(nameof(ApplyFallForce), RpcTarget.All);
@@ -39,7 +41,7 @@ public class FallingClockHand : MonoBehaviourPun
     [PunRPC]
     void ApplyFallForce()
     {
-        rb.AddForce(Vector3.down * fallForce, ForceMode.Acceleration);
+        _rb.AddForce(Vector3.down * fallForce, ForceMode.Acceleration);
     }
 
     private IEnumerator ReturnAfterDelay()
@@ -57,29 +59,37 @@ public class FallingClockHand : MonoBehaviourPun
     /// </summary>
     private void StickToGround()
     {
-        rb.velocity = Vector3.zero;
-        rb.angularVelocity = Vector3.zero;
-        rb.isKinematic = true;
+        _rb.velocity = Vector3.zero;
+        _rb.angularVelocity = Vector3.zero;
+        _rb.isKinematic = true;
 
         transform.position += Vector3.down * stickOffset;
+
+        // 땅에 닿은 바늘로 플레이어가 죽을 수 없도록 처리
+        _killTrigger.enabled = false;
+        _solidCollider.enabled = true;
     }
 
-    private void OnCollisionEnter(Collision collision)
+    private void OnTriggerEnter(Collider other)
     {
         if (!PhotonNetwork.IsMasterClient)
             return;
 
-        if (collision.gameObject.layer == LayerMask.NameToLayer("Ground"))
+        if (other.gameObject.layer == LayerMask.NameToLayer("Ground"))
         {
             StickToGround();
             StartCoroutine(ReturnAfterDelay());
         }
-
-        CharacterBase character = collision.collider.GetComponentInParent<CharacterBase>();
-        if (character != null)
+        else
         {
-            BattleLifeManager.Instance.RecordHitPosition(character, character.transform.position);
-            character.ChangeState<DeadState>(Define.Battle.DeathType.Collision);
+            CharacterBase character = other.GetComponentInParent<CharacterBase>();
+
+            // 상호작용 트리거로 죽지 않도록 플레이어 태그도 검사
+            if (other.IsPlayerCollider() && character != null && _killTrigger.enabled)
+            {
+                BattleLifeManager.Instance.RecordHitPosition(character, character.transform.position);
+                character.ChangeState<DeadState>(Define.Battle.DeathType.Collision);
+            }
         }
     }
 }

--- a/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/FallingClockHand.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/FallingClockHand.cs
@@ -75,9 +75,6 @@ public class FallingClockHand : MonoBehaviourPun
 
     private void OnTriggerEnter(Collider other)
     {
-        if (!PhotonNetwork.IsMasterClient)
-            return;
-
         if (other.gameObject.layer == LayerMask.NameToLayer("Ground"))
         {
             StickToGround();

--- a/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/SwingAttack.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/SwingAttack.cs
@@ -21,7 +21,7 @@ public class SwingAttack : AttackPattern
 
     // 최소/최대 스폰 횟수
     private const int minSpawnNum = 1;
-    private const int maxSpawnNum = 4;
+    private const int maxSpawnNum = 5;
 
     private const int additionalAttackCount = 3; // 라운드 증가할 때마다 늘어날 공격 횟수
     private readonly float[] startAngles = { -60f, 60f };

--- a/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/SwingPendulum.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/BossAttack/SwingPendulum.cs
@@ -94,10 +94,9 @@ public class SwingPendulum : MonoBehaviourPun
         if (!PhotonNetwork.IsMasterClient)
             return;
 
-        if(collision.collider.IsPlayerCollider())
+        CharacterBase character = collision.collider.GetComponentInParent<CharacterBase>();
+        if (character != null)
         {
-            // 플레이어 사망 처리
-            CharacterBase character = collision.collider.GetComponentInParent<CharacterBase>();
             BattleLifeManager.Instance.RecordHitPosition(character, character.transform.position);
             character.ChangeState<DeadState>(Define.Battle.DeathType.Collision);
         }

--- a/ClockMate/Assets/02.Scripts/ClockTower/Life/BattleLifeManager.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/Life/BattleLifeManager.cs
@@ -13,6 +13,7 @@ public class BattleLifeManager : MonoBehaviourPun
     public static BattleLifeManager Instance { get; private set; }
 
     private const float ReviveDelay = 3f;
+    private const float safeTime = 0.1f;
 
     private void Awake()
     {
@@ -51,6 +52,16 @@ public class BattleLifeManager : MonoBehaviourPun
 
         character.ChangeState<IdleState>();
         character.transform.position = revivePos;
+
+        if(BattleManager.Instance.phaseType == PhaseType.SwingAttack)
+        {
+            // SwingAttack 중 부활 시 플레이어 미끄러짐 방지
+            Rigidbody rb = character.GetComponent<Rigidbody>();
+
+            rb.isKinematic = true;
+            yield return new WaitForSeconds(safeTime);
+            rb.isKinematic = false;
+        }
 
         deadPlayers.Remove(character.GetComponent<PhotonView>().ViewID);
     }

--- a/ClockMate/Assets/02.Scripts/ClockTower/Life/BattleLifeManager.cs
+++ b/ClockMate/Assets/02.Scripts/ClockTower/Life/BattleLifeManager.cs
@@ -47,11 +47,11 @@ public class BattleLifeManager : MonoBehaviourPun
         yield return new WaitForSeconds(ReviveDelay);
 
         IReviveStrategy strategy = GetStrategy(character, deathType);
-
         Vector3 revivePos = strategy.GetRevivePosition();
-        character.transform.position = revivePos;
 
         character.ChangeState<IdleState>();
+        character.transform.position = revivePos;
+
         deadPlayers.Remove(character.GetComponent<PhotonView>().ViewID);
     }
 

--- a/ClockMate/Assets/02.Scripts/Game/FallDeathZone.cs
+++ b/ClockMate/Assets/02.Scripts/Game/FallDeathZone.cs
@@ -9,11 +9,12 @@ public class FallDeathZone : MonoBehaviour
     {
         if(other.IsPlayerCollider())
         {
+            CharacterBase character = other.gameObject.GetComponentInParent<CharacterBase>();
+
             if (SceneManager.GetActiveScene().name == "ClockTower")
                 character.ChangeState<DeadState>(Define.Battle.DeathType.Fall);
             else
-                CharacterBase character = other.gameObject.GetComponentInParent<CharacterBase>();
-                //character.ChangeState<DeadState>();
+            {
                 Vector3 loadPosition = GameManager.Instance.CurrentStage.LoadPositions[character.Name];
                 character.transform.position = loadPosition;
                 if (poofEffect != null)
@@ -21,6 +22,7 @@ public class FallDeathZone : MonoBehaviour
                     Instantiate(poofEffect, loadPosition, Quaternion.identity);
                 }
                 character.ChangeState<IdleState>();
+            }
         }
     }
 }

--- a/ClockMate/Assets/02.Scripts/Network/CharacterSelect/CharacterSelectFinalizer.cs
+++ b/ClockMate/Assets/02.Scripts/Network/CharacterSelect/CharacterSelectFinalizer.cs
@@ -13,7 +13,6 @@ public class CharacterSelectFinalizer : MonoBehaviourPun
     public GameObject Player2Ready;
 
     private bool _isLoadingStarted = false;
-    private bool _isCutsceneFinished = false;   // 컷씬 끝났는지 확인
 
     private void Start()
     {

--- a/ClockMate/Assets/02.Scripts/Player/States/DeadState.cs
+++ b/ClockMate/Assets/02.Scripts/Player/States/DeadState.cs
@@ -31,10 +31,6 @@ public class DeadState : IState
                 BattleLifeManager.Instance.HandleDeath(_character, _deathType);
             }
         }
-        else
-        {
-            
-        }
     }
 
     public void FixedUpdate()

--- a/ClockMate/Assets/02.Scripts/Util/NetworkObjectPool.cs
+++ b/ClockMate/Assets/02.Scripts/Util/NetworkObjectPool.cs
@@ -84,9 +84,7 @@ public class NetworkObjectPool<T> : MonoBehaviourPunCallbacks where T : MonoBeha
             return;
 
         int viewID = obj.photonView.ViewID;
-
-        if (PhotonNetwork.IsMasterClient)
-            photonView.RPC(nameof(RPC_DeactivateObject), RpcTarget.All, viewID);
+        photonView.RPC(nameof(RPC_DeactivateObject), RpcTarget.All, viewID);
     }
 
     private T GetInactiveObject()

--- a/ClockMate/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/ClockMate/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -142,6 +142,9 @@ MonoBehaviour:
   - HandleSuccess
   - RPC_PlayReviveEffect
   - RPC_SetObjectActive
+  - RPC_GripAnchorClear
+  - RPC_GripAnchorTarget
+  - RPC_SetDizzy
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/ClockMate/Assets/Resources/Characters/Milli.prefab
+++ b/ClockMate/Assets/Resources/Characters/Milli.prefab
@@ -247,6 +247,7 @@ MonoBehaviour:
   pFanFly: FanFly
   pPickUp: PickUp
   pCarry: Carry
+  pDizzy: Dizzy
   speedLerp: 0.2
   walkTag: Walk
   walkMarks:

--- a/ClockMate/Assets/Resources/Prefabs/FallingClockHand.prefab
+++ b/ClockMate/Assets/Resources/Prefabs/FallingClockHand.prefab
@@ -11,10 +11,11 @@ GameObject:
   - component: {fileID: 2036523448431071040}
   - component: {fileID: 8930371032555722910}
   - component: {fileID: 1607878309115371400}
-  - component: {fileID: 2550471849393704120}
   - component: {fileID: 4961854488939124626}
   - component: {fileID: 7732525753689094633}
   - component: {fileID: 3665366428022518616}
+  - component: {fileID: 2550471849393704120}
+  - component: {fileID: 3858762408003710369}
   m_Layer: 0
   m_Name: FallingClockHand
   m_TagString: Untagged
@@ -87,29 +88,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!136 &2550471849393704120
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8014313991052622129}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!114 &4961854488939124626
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -122,6 +100,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fd37baeab25208a4b83192aa798924fd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _killTrigger: {fileID: 2550471849393704120}
+  _solidCollider: {fileID: 3858762408003710369}
 --- !u!54 &7732525753689094633
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -172,3 +152,49 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!136 &2550471849393704120
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8014313991052622129}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!136 &3858762408003710369
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8014313991052622129}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}


### PR DESCRIPTION
## 전투 물리/플레이어 충돌 관련 버그 해결
### 좌우 공격
- 플레이어가 여러 개의 보스 공격 오브젝트(시계추)와 동시에 충돌할 때 발생하는 널 에러 해결 완료
- Swing Attack 중 부활 시 이전에 부딪힌 위치, 즉 오브젝트의 진자 운동 반경에서 다시 부활함. 이로 인해 플레이어가 미끄러지며 부활하는 문제 발생. 부활 후 0.1초 동안 isKinematic을 활성화하여 문제 해결

### 상하 공격
- 바늘이 떨어지는 중에 플레이어가 닿으면 죽도록 함.
떨어지는 중에 물리적 충돌로 인해 물리 버그가 발생하는 것을 방지하고자, 트리거로 감지하도록 수정
- 바늘이 땅에 닿은 상태에서 충돌하면 죽지 않되, 물리적 충돌은 가능하도록(오브젝트를 통과할 수 없도록) 처리
- 시계 바늘이 땅에 닿았음에도 일정 시간이 지나도 제거되지 않는 문제 해결. 오브젝트 풀로 재사용된 객체의 콜라이더가 초기화 되지 않아서 발생한 문제
- 비마스터에서 시계 바늘이 땅을 뚫고 떨어지는 문제 해결